### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pip install -r requirements.txt && bash -c polygott-x11-vnc q && DISPLAY=:0 run-project"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/emwjacobson/Pygame)](https://repl.it/github/emwjacobson/Pygame)
+
 # This is my game
 
 ## Installation


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).